### PR TITLE
Fix evict cache on file change #12 and load-file issue #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.idea/
+*.iml

--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -30,7 +30,7 @@
   (when (and file (.exists (io/file file)))
     (io/file file)))
 
-(defn resource->containing-file
+(defn ^File resource->containing-file
   "This function returns the containing file of a resource.
 
   This can be a JAR file for a clj resource inside a dependency,

--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -68,10 +68,11 @@
   both the filepath and md5 sum of the file.
   This is the function that is actually memoized, and thus
   the cache will not return old or expired files."
-  (let [invoke-file-source (fn [filepath _] (file-source filepath)) ; ignore the second argument, only used by cache
-        memoized-file-source (lu invoke-file-source :lu/threshold 64)]
+  (let [cached-fn (lu (fn [filepath _] ; ignore md5 argument, only used by memoize/lu
+                        (file-source filepath))
+                      :lu/threshold 64)]
     (fn [filepath]
-      (memoized-file-source filepath (filepath->md5 filepath)))))
+      (cached-fn filepath (filepath->md5 filepath)))))
 
 (defn source-fn
   "A function for pulling in source code.

--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -30,11 +30,18 @@
   (when (and file (.exists (io/file file)))
     (io/file file)))
 
-(defn resource->file
+(defn resource->containing-file
+  "This function returns the containing file of a resource.
+
+  This can be a JAR file for a clj resource inside a dependency,
+  or a regular clj file for a clj resource used during development."
   [filepath]
   (when-let [url (io/resource filepath)]
     (let [url-str (str url)]
       (cond (str/starts-with? url-str (str "jar:file:" File/separator))
+            ; This handles clj files inside JARs, such as
+            ; (resource->file "clojure/java/io.clj")
+            ; => #object[java.io.File 0x74900942 "/home/ire/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar"]
             (-> url-str
                 (subs (count "jar:file:"))
                 (URLDecoder/decode "UTF-8")
@@ -43,6 +50,9 @@
                 ((fn [x] (str/join "!" x)))
                 (file-exists-or-nil))
 
+            ; This handles standalone clj files present during development, such as
+            ; (io/resource "pyro/source.clj")
+            ; => #object[java.net.URL 0x2ab4619e "file:/home/ire/code/github/pyro/src/pyro/source.clj"]
             (str/starts-with? url-str (str "file:" File/separator))
             (-> url-str
                 (subs (count "file:"))
@@ -51,7 +61,7 @@
 
 (defn filepath->lastModified
   [filepath]
-  (when-let [file (or (resource->file filepath)
+  (when-let [file (or (resource->containing-file filepath)
                       (file-exists-or-nil filepath))]
     (.lastModified file)))
 
@@ -62,14 +72,24 @@
     (BufferedReader. (InputStreamReader. strm StandardCharsets/UTF_8))))
 
 (defn file-source
-  [[filepath _]]
+  "A function for getting colorized source of filepath."
+  [filepath]
   (terminal/ansi-colorize
    colorschemes/terminal-default
    (parse/parse
     (string/join "\n" (line-seq (filepath->buffered-reader filepath))))))
 
 (def memoized-file-source
-  (lu file-source :lu/threshold 64))
+  "Returns a memoized file-source function that detects changes to files.
+
+  This function invokes an inner function taking two arguments,
+  both the filepath and the lastModified of the file.
+  This is the function that is actually memoized, and thus
+  the cache will never return old or expired files."
+  (let [invoke-file-source (fn [filepath _] (file-source filepath))
+        memoized-file-source (lu invoke-file-source :lu/threshold 64)]
+    (fn [filepath]
+      (memoized-file-source filepath (filepath->lastModified filepath)))))
 
 (defn source-fn
   "A function for pulling in source code.
@@ -79,7 +99,7 @@
   n preceding and following lines."
   {:added "0.1.0"}
   [filepath line number]
-  (let [rdr (memoized-file-source [filepath (filepath->lastModified filepath)])]
+  (let [rdr (memoized-file-source filepath)]
     (let [content (drop (- line (inc number))
                         (string/split rdr #"\n"))
           pre (take number content)

--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -5,9 +5,11 @@
             [glow.colorschemes :as colorschemes]
             [glow.terminal :as terminal]
             [glow.parse :as parse]
-            [instaparse.core :as insta])
+            [clojure.java.io :as io]
+            [clojure.string :as str])
   (:import [clojure.lang RT]
-           [java.io BufferedReader InputStreamReader]))
+           [java.io BufferedReader InputStreamReader]
+           (java.nio.charset StandardCharsets)))
 
 (defn pad-integer
   "Right-pad an integer with spaces until it takes up 4 character spaces."
@@ -23,13 +25,41 @@
   [s n]
   (str "--> " (pad-integer n) " " s))
 
+(defn filepath->lastModified
+  [filepath]
+  (let [url (io/resource filepath)
+        file (io/file filepath)]
+    (cond
+      ; handle files inside JARs
+      ; (io/resource "clojure/java/io.clj") =>
+      ; URL "jar:file:/Users/ivref/.m2/repository/org/clojure/clojure/1.8.0/clojure-1.8.0.jar!/clojure/java/io.clj"
+      (and url (= "jar" (.getProtocol url))) (-> url
+                                                 (.getFile)
+                                                 (str/split #"!")
+                                                 (first)
+                                                 (subs 5) ; remove file:
+                                                 (io/file)
+                                                 (.lastModified))
+
+      ; handle local files loaded using require and similar
+      ; (io/resource "pyro/source.clj") =>
+      ; URL "file:/Users/ivref/clojure/pyro/src/pyro/source.clj"
+      (and url (= "file" (.getProtocol url))) (-> url (.getFile) (io/file) (.lastModified))
+
+      ; handle files loaded using Cursive, load-file and similar
+      (.exists file) (.lastModified file)
+
+      :else (throw (ex-info "Could not find lastModified of filepath" {:filepath filepath})))))
+
 (defn filepath->buffered-reader
   [filepath]
-  (when-let [strm (.getResourceAsStream (RT/baseLoader) filepath)]
-    (BufferedReader. (InputStreamReader. strm))))
+  (if-let [strm (or (.getResourceAsStream (RT/baseLoader) filepath)
+                    (io/input-stream (io/file filepath)))]
+    (BufferedReader. (InputStreamReader. strm StandardCharsets/UTF_8))
+    (throw (ex-info "Could not get stream" {:filepath filepath}))))
 
 (defn file-source
-  [filepath]
+  [[filepath _]]
   (terminal/ansi-colorize
    colorschemes/terminal-default
    (parse/parse
@@ -46,7 +76,7 @@
   n preceding and following lines."
   {:added "0.1.0"}
   [filepath line number]
-  (let [rdr (memoized-file-source filepath)]
+  (let [rdr (memoized-file-source [filepath (filepath->lastModified filepath)])]
     (let [content (drop (- line (inc number))
                         (string/split rdr #"\n"))
           pre (take number content)

--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -61,7 +61,7 @@
    (parse/parse
     (string/join "\n" (line-seq (filepath->buffered-reader filepath))))))
 
-(defn cacheable-file-source
+(defn- cacheable-file-source
   "A version of `file-source` that also takes the md5 hash of the file as an arg
   in order to permit caching on the file's contents.
 
@@ -69,7 +69,7 @@
   [path md5]
   (file-source path))
 
-(def cached-file-source
+(def ^:private cached-file-source
   (lu cacheable-file-source :lu/threshold 64))
 
 (defn memoized-file-source

--- a/test/pyro/dummyæøå.clj
+++ b/test/pyro/dummyæøå.clj
@@ -1,0 +1,3 @@
+(ns pyro.dummyæøå)
+
+(def foo 123)

--- a/test/pyro/dummyæøå.clj
+++ b/test/pyro/dummyæøå.clj
@@ -1,3 +1,0 @@
-(ns pyro.dummyæøå)
-
-(def foo 123)

--- a/test/pyro/source_test.clj
+++ b/test/pyro/source_test.clj
@@ -1,6 +1,7 @@
 (ns pyro.source-test
   (:require [clojure.test :refer :all]
-            [pyro.source :as source]))
+            [pyro.source :as source]
+            [clojure.string :as str]))
 
 (deftest pad-integer-test
   (is (= (source/pad-integer 5) "5   "))
@@ -27,3 +28,16 @@
                                    :fn "sample-var"
                                    :file "core_test.clj"})
          "pyro/core_test.clj")))
+
+(deftest resource->containing-file-test
+  ; verify standalone clj files and special characters (URLDecoder/decode)
+  (do (require 'pyro.dummyæøå)
+      (is (-> (source/resource->containing-file "pyro/dummyæøå.clj")
+              (.getAbsolutePath)
+              (str/ends-with? "pyro/dummyæøå.clj"))))
+  ; verify jar file
+  (is (-> (source/resource->containing-file "clojure/java/io.clj")
+          (.getAbsolutePath)
+          (str/ends-with? "clojure-1.8.0.jar")))
+  ; missing resource should return nil
+  (is (nil? (source/resource->containing-file "not-found.clj"))))

--- a/test/pyro/source_test.clj
+++ b/test/pyro/source_test.clj
@@ -30,6 +30,20 @@
                                    :file "core_test.clj"})
          "pyro/core_test.clj")))
 
+(deftest filepath->stream-test
+  (is (some? (source/filepath->stream "clojure/java/io.clj")))
+  (is (some? (source/filepath->stream "pyro/core_test.clj")))
+  (is (nil? (source/filepath->stream "not-found.clj"))))
+
+(deftest filepath->md5-test
+  (let [tempfile "test/pyro/tempfile2.clj"]
+    (try
+      (spit tempfile "(ns pyro.tempfile2)\n(def dummy1 123)\n")
+      (is (= "C08A2A68570425ABB29E292C89A5B9EC" (source/filepath->md5 tempfile)))
+      (is (nil? (source/filepath->md5 "not-found.clj")))
+      (finally
+        (-> (io/file tempfile) (.delete))))))
+
 (deftest memoized-file-source-test
   (let [tempfile "test/pyro/tempfile.clj"]
     (try


### PR DESCRIPTION
This should fix both #12 and #11.

With respect to performance I found the following approximate numbers:
```clojure
(time (let [x (file-source ["clojure/java/io.clj" :ignore])] :ignore)) ; about 100 ms on my machine
(time (filepath->lastModified "clojure/java/io.clj")) ; about 0.2 ms
```
So there is considerable gain in using the cache, and the added `filepath->lastModified` is not very expensive, but should be sufficient for cache eviction.

The function `filepath->lastModified` is not the most pretty code I've written, and I'm definitely open to improvements.

Regards