### PR TITLE
Clojure 1.8.0 support

### DIFF
--- a/src/pyro/source.clj
+++ b/src/pyro/source.clj
@@ -2,6 +2,7 @@
   "A namespace for reading source code off of the classpath"
   (:require [clojure.core.memoize :refer [lu]]
             [clojure.string :as string]
+            [glow.ansi :as ansi]
             [glow.colorschemes :as colorschemes]
             [glow.terminal :as terminal]
             [glow.parse :as parse]
@@ -94,10 +95,12 @@
           line-code (nth content number)
           post (drop (inc number)
                      (take (inc (* number 2)) content))]
-      (string/join "\n" (flatten
+      (str (string/join "\n"
+                        (flatten
                          [(map pad-source pre (range (- line number) line))
                           (pad-source-arrow line-code line)
-                          (map pad-source post (range (inc line) (inc (+ line number))))])))))
+                          (map pad-source post (range (inc line) (inc (+ line number))))]))
+           ansi/reset-font))))
 
 (defn ns->filename
   "Given a namespace string, convert it to a filename."

--- a/test/pyro/core_test.clj
+++ b/test/pyro/core_test.clj
@@ -5,4 +5,7 @@
 (def sample-var)
 
 (deftest ^:demo sample-failure
-  (is (some? (dummy-fns/i-dont-work))))
+  (is (some? (dummy-fns/i-dont-work)))
+  "this
+  is
+  :a")


### PR DESCRIPTION
This commit reloads clojure.test after altering the var roots - this is
necessary because Clojure 1.8.0+ links clojure.test directly into
clojure.stacktrace, so we need to re-evaluate the namespace after having made our modifications.

It also makes a minor tweak in how source is printed to keep colorized
source from overflowing into the REPL session, but this doesn't fix a
number of cases and an ultimate fix will probably require a material
change in Glow upstream.